### PR TITLE
add standard error example to predict.Rmd

### DIFF
--- a/src/predict.Rmd
+++ b/src/predict.Rmd
@@ -135,19 +135,19 @@ head(getPredictionProbabilities(pred))
 
 ### Extract Standard Errors
 
-Some Learners provide standard errors for predictions, which can be accessed in mlr. An overview is given [&listLearners].
+Some Learners provide standard errors for predictions, which can be accessed in mlr. An overview is given by calling the function[&listLearners]. In order to include learners from packages which are not installed in the overview, one has to set ``check.packages``  as ``FALSE``.
 
-```{r, results='hide'}
+```{r, results='hide', warning=FALSE}
 listLearners("regr", check.packages = FALSE)
 ```
 
-In this example we train a Gaussian Process Regression on the Boston Housing dataset. For the learner, the ``predict.type`` has to be specified as correctly:
+In this example we train a Gaussian Process Regression on the Boston Housing dataset. Since the Gaussian Process, ``regr.km``, does not allow factor data, we have to use only numerical variables  for the training. For the learner, the ``predict.type`` has to be specified as correctly:
 
 ```{r, results='hide'}
-# Select only numeric variables
+## Select only numeric variables
 bh.task.part = subsetTask(bh.task, features = 5:13)
 
-# Create Learner, specify predict.type
+## Create Learner, specify predict.type
 lrn.km = makeLearner("regr.km", predict.type = 'se')
 mod.km = train(lrn.km, bh.task.part, subset = train.set)
 task.pred.km = predict(mod.km, task = bh.task.part, subset = test.set)

--- a/src/predict.Rmd
+++ b/src/predict.Rmd
@@ -133,6 +133,32 @@ As mentioned above, the predicted posterior probabilities can be accessed via th
 head(getPredictionProbabilities(pred))
 ```
 
+### Extract Standard Errors
+
+Some Learners provide standard errors for predictions, which can be accessed in mlr. An overview is given [&listLearners].
+
+```{r, results='hide'}
+listLearners("regr", check.packages = FALSE)
+```
+
+In this example we train a Gaussian Process Regression on the Boston Housing dataset. For the learner, the ``predict.type`` has to be specified as correctly:
+
+```{r, results='hide'}
+# Select only numeric variables
+bh.task.part = subsetTask(bh.task, features = 5:13)
+
+# Create Learner, specify predict.type
+lrn.km = makeLearner("regr.km", predict.type = 'se')
+mod.km = train(lrn.km, bh.task.part, subset = train.set)
+task.pred.km = predict(mod.km, task = bh.task.part, subset = test.set)
+```
+
+The standard errors can then be extracted usting [&getPredictionSE].
+
+```{r}
+head(getPredictionSE(task.pred.km))
+```
+
 ### Confusion matrix
 
 A confusion matrix can be obtained by calling [&calculateConfusionMatrix]. The columns represent

--- a/src/predict.Rmd
+++ b/src/predict.Rmd
@@ -86,6 +86,30 @@ head(getPredictionResponse(task.pred))
 ```
 
 
+### Extract Standard Errors
+Some learners provide standard errors for predictions, which can be accessed in mlr. An overview is given by calling the function [&listLearners] and setting ``properties = "se"``. By assigning ``FALSE`` to ``check.packages`` learners from packages which are not installed will be included in the overview.
+
+```{r}
+listLearners("regr", check.packages = FALSE, properties = "se")
+```
+
+In this example we train a linear regression model on the Boston Housing dataset. In order to calculate standard errors set the ``predict.type`` to ``"se"``:
+
+```{r}
+## Create Learner, specify predict.type
+lrn.lm = makeLearner("regr.lm", predict.type = 'se')
+mod.lm = train(lrn.lm, bh.task, subset = train.set)
+task.pred.lm = predict(mod.lm, task = bh.task, subset = test.set)
+task.pred.lm
+```
+
+The standard errors can then be extracted using [&getPredictionSE].
+
+```{r}
+head(getPredictionSE(task.pred.lm))
+```
+
+
 ### Extract Probabilities
 The predicted probabilities can be extracted from the [&Prediction] using the function
 [&getPredictionProbabilities].
@@ -133,31 +157,6 @@ As mentioned above, the predicted posterior probabilities can be accessed via th
 head(getPredictionProbabilities(pred))
 ```
 
-### Extract Standard Errors
-
-Some Learners provide standard errors for predictions, which can be accessed in mlr. An overview is given by calling the function[&listLearners]. In order to include learners from packages which are not installed in the overview, one has to set ``check.packages``  as ``FALSE``.
-
-```{r, results='hide', warning=FALSE}
-listLearners("regr", check.packages = FALSE)
-```
-
-In this example we train a Gaussian Process Regression on the Boston Housing dataset. Since the Gaussian Process, ``regr.km``, does not allow factor data, we have to use only numerical variables  for the training. For the learner, the ``predict.type`` has to be specified as correctly:
-
-```{r, results='hide'}
-## Select only numeric variables
-bh.task.part = subsetTask(bh.task, features = 5:13)
-
-## Create Learner, specify predict.type
-lrn.km = makeLearner("regr.km", predict.type = 'se')
-mod.km = train(lrn.km, bh.task.part, subset = train.set)
-task.pred.km = predict(mod.km, task = bh.task.part, subset = test.set)
-```
-
-The standard errors can then be extracted usting [&getPredictionSE].
-
-```{r}
-head(getPredictionSE(task.pred.km))
-```
 
 ### Confusion matrix
 


### PR DESCRIPTION
Resolves issue #77.

Adds an example with standard error for predictions, using `predict.type` and `getPredictionSE()`. 
`listLearners()` function shortly explained as well.