### PR TITLE
fix recent travis issue

### DIFF
--- a/src/benchmark_experiments.Rmd
+++ b/src/benchmark_experiments.Rmd
@@ -554,7 +554,7 @@ matrix of mean misclassification errors ([mmce](&measures.md)) on the [Sonar](&m
 data set.
 
 ```{r}
-perf = getBMRPerformances(bmr, task.id = "Sonar-Example", as.df = TRUE)
+perf = getBMRPerformances(bmr, task.id = "Sonar-example", as.df = TRUE)
 df = reshape2::melt(perf, id.vars = c("task.id", "learner.id", "iter"))
 df = df[df$variable == "mmce",]
 df = reshape2::dcast(df, task.id + iter ~ variable + learner.id)

--- a/src/benchmark_experiments.Rmd
+++ b/src/benchmark_experiments.Rmd
@@ -524,7 +524,7 @@ perf = getBMRPerformances(bmr, as.df = TRUE)
 
 ## Density plots for two tasks
 qplot(mmce, colour = learner.id, facets = . ~ task.id,
-  data = perf[perf$task.id %in% c("iris_example", "Sonar_example"),], geom = "density") +
+  data = perf[perf$task.id %in% c("iris-example", "Sonar-Example"),], geom = "density") +
   theme(strip.text.x = element_text(size = 8))
 ```
 
@@ -554,7 +554,7 @@ matrix of mean misclassification errors ([mmce](&measures.md)) on the [Sonar](&m
 data set.
 
 ```{r}
-perf = getBMRPerformances(bmr, task.id = "Sonar_example", as.df = TRUE)
+perf = getBMRPerformances(bmr, task.id = "Sonar-Example", as.df = TRUE)
 df = reshape2::melt(perf, id.vars = c("task.id", "learner.id", "iter"))
 df = df[df$variable == "mmce",]
 df = reshape2::dcast(df, task.id + iter ~ variable + learner.id)

--- a/src/nested_resampling.Rmd
+++ b/src/nested_resampling.Rmd
@@ -370,11 +370,11 @@ It is also possible to extract the tuning results for individual tasks and learn
 as shown in earlier examples, inspect the [optimization path](&ParamHelpers::OptPath).
 
 ```{r}
-tune.res = getBMRTuneResults(res, task.ids = "Sonar_example", learner.ids = "classif.ksvm.tuned",
+tune.res = getBMRTuneResults(res, task.ids = "Sonar-example", learner.ids = "classif.ksvm.tuned",
   as.df = TRUE)
 tune.res
 
-getNestedTuneResultsOptPathDf(res$results[["Sonar_example"]][["classif.ksvm.tuned"]])
+getNestedTuneResultsOptPathDf(res$results[["Sonar-example"]][["classif.ksvm.tuned"]])
 ```
 
 


### PR DESCRIPTION
`Sonar_example` again changed to `Sonar-Example` in recent mlr commit. Probably related to new generation of data sets